### PR TITLE
Changed the use of "firmware" to more conventional "software"

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -84,14 +84,14 @@ Main Goal of this phase is to Port the CodeLab to platform independent Web envir
 - 🏁 ***Client Proxy apps Built for Android and Iphone***
 
 
-## Phase III. - Cyb3rVector's Codelab Firmware
+## Phase III. - Cyb3rVector's Codelab Software
 
-This stage will focus on creating a specific version of Vector's CodeLab which will be hosted directly from Vector, allowing the users to login to Vector's CodeLab hosted on Vector's firmware from any device in the local network.
+This stage will focus on creating a specific version of Vector's CodeLab which will be hosted directly from Vector, allowing the users to login to Vector's CodeLab hosted on Vector's software from any device in the local network.
 
 - 🏁 ***Obtaining OSKR***
 - 🏁 ***Creating CodeLab port to run directly from Vector***
-- 🏁 ***Deploying the CodeLab port to OSKR Firmware***
-- 🏁 ***Extending the Firmware and CodeLab capabilities***
+- 🏁 ***Deploying the CodeLab port to OSKR Software***
+- 🏁 ***Extending the Software and CodeLab capabilities***
 
 
 ## Just a word before you go...


### PR DESCRIPTION
Great project! As someone who still is on WinForms (and loving it), I hope someday to see how you did the UI in WPF.

I changed the use of "firmware" to "software" to be more consistent.  Only a couple of tiny parts of Vector are called firmware -- the cube firmware and the body board firmware.